### PR TITLE
feat(#470): Added more context in the `ReactiveFeignException`

### DIFF
--- a/feign-reactor-core/src/main/java/reactivefeign/client/ReactiveFeignException.java
+++ b/feign-reactor-core/src/main/java/reactivefeign/client/ReactiveFeignException.java
@@ -1,11 +1,13 @@
 package reactivefeign.client;
 
-public class ReactiveFeignException extends RuntimeException{
+public class ReactiveFeignException extends RuntimeException {
+
+    public static final String MESSAGE_PATTERN = "Problem with the request: %s";
 
     private final ReactiveHttpRequest request;
 
     public ReactiveFeignException(Throwable cause, ReactiveHttpRequest request) {
-        super(cause);
+        super(String.format(MESSAGE_PATTERN, request), cause);
         this.request = request;
     }
 

--- a/feign-reactor-core/src/main/java/reactivefeign/client/ReactiveHttpRequest.java
+++ b/feign-reactor-core/src/main/java/reactivefeign/client/ReactiveHttpRequest.java
@@ -85,4 +85,18 @@ public final class ReactiveHttpRequest {
     return methodMetadata.configKey();
   }
 
+  public Target<?> target() {
+    return target;
+  }
+
+  @Override
+  public String toString() {
+    return "ReactiveHttpRequest{" +
+            "methodMetadata=" + methodMetadata +
+            ", target=" + target +
+            ", uri=" + uri +
+            ", headers=" + headers +
+            ", body=" + body +
+            '}';
+  }
 }


### PR DESCRIPTION
Now it is possible to view the full request representation in the exception message. Not all fields have a decent `Object#toString` representation, but it clarifies what the request was. I think that this is very useful in problem-solving.

Closes #470 